### PR TITLE
Feat/transaction routes logic

### DIFF
--- a/packages/proxy/src/routes/address.ts
+++ b/packages/proxy/src/routes/address.ts
@@ -17,23 +17,6 @@ export const addressParamsSchema = {
   }),
 };
 
-export type Paginated<T> = {
-  items: T[];
-  meta: {
-    totalItems: number;
-    itemCount: number;
-    itemsPerPage: number;
-    totalPages: number;
-    currentPage: number;
-  };
-  links: {
-    first: string;
-    previous: string;
-    next: string;
-    last: string;
-  };
-};
-
 const transfersSchema = {
   params: z.object({
     address: addressSchema,

--- a/packages/proxy/src/routes/address.ts
+++ b/packages/proxy/src/routes/address.ts
@@ -4,15 +4,7 @@ import { isAddressEqual } from 'viem';
 import { pipeGetRequest } from '../services/block-explorer.js';
 import { getUserOrThrow } from '../services/user.js';
 import { ForbiddenError } from '../utils/http-error.js';
-import {
-  addressSchema,
-  enumeratedLogSchema,
-  enumeratedTransferSchema,
-  logsSchema,
-  transferSchema,
-} from '../utils/schemas.js';
-import { buildUrl } from '../utils/url.js';
-import { wrapIntoPaginationInfo } from '../utils/pagination.js';
+import { addressSchema, logsSchema, transferSchema } from '../utils/schemas.js';
 import { requestAndFilterCollection } from '../utils/request-and-filter-collection.js';
 
 export const addressParamsSchema = {

--- a/packages/proxy/src/routes/address.ts
+++ b/packages/proxy/src/routes/address.ts
@@ -7,6 +7,7 @@ import { ForbiddenError } from '../utils/http-error.js';
 import {
   addressSchema,
   enumeratedSchema,
+  enumeratedTransferSchema,
   hexSchema,
 } from '../utils/schemas.js';
 import { buildUrl } from '../utils/url.js';
@@ -53,32 +54,6 @@ const transfersSchema = {
     toDate: z.optional(z.string()),
   }),
 };
-
-export const tokenSchema = z.object({
-  l2Address: hexSchema,
-  l1Address: hexSchema,
-  symbol: z.string(),
-  name: z.string(),
-  decimals: z.number(),
-  usdPrice: z.number(),
-  liquidity: z.number(),
-  iconURL: z.string(),
-});
-
-export const transferSchema = z.object({
-  from: hexSchema,
-  to: hexSchema,
-  blockNumber: z.number(),
-  transactionHash: hexSchema,
-  amount: z.string(),
-  token: tokenSchema,
-  tokenAddress: hexSchema,
-  type: z.enum(['deposit', 'transfer', 'withdrawal', 'fee', 'mint', 'refund']),
-  timestamp: z.string(),
-  fields: z.any(),
-});
-
-const enumeratedTransferSchema = enumeratedSchema(transferSchema);
 
 const enumeratedLogSchema = enumeratedSchema(
   z.object({

--- a/packages/proxy/src/routes/batches-bff.ts
+++ b/packages/proxy/src/routes/batches-bff.ts
@@ -1,5 +1,4 @@
 import type { FastifyApp } from '../app.js';
-import { buildUrl } from '../utils/url.js';
 import { z } from 'zod';
 import { pipeGetRequest } from '../services/block-explorer.js';
 

--- a/packages/proxy/src/routes/blocks-bff.ts
+++ b/packages/proxy/src/routes/blocks-bff.ts
@@ -29,7 +29,10 @@ export function blocksRoutes(app: FastifyApp) {
   });
 
   app.get('/:blockNumber', blocksDetailSchema, async (req, reply) => {
-    const targetUrl = buildUrl(`${app.conf.proxyTarget}/blocks/${req.params.blockNumber}`, {});
+    const targetUrl = buildUrl(
+      `${app.conf.proxyTarget}/blocks/${req.params.blockNumber}`,
+      {},
+    );
     return pipeGetRequest(targetUrl, reply);
   });
 }

--- a/packages/proxy/src/routes/transactions-bff.ts
+++ b/packages/proxy/src/routes/transactions-bff.ts
@@ -3,16 +3,13 @@ import { pipeGetRequest } from '../services/block-explorer.js';
 import { z } from 'zod';
 import {
   addressSchema,
-  enumeratedLogSchema,
   enumeratedSchema,
-  enumeratedTransferSchema,
   hexSchema,
   logsSchema,
   transferSchema,
 } from '../utils/schemas.js';
 import { wrapIntoPaginationInfo } from '../utils/pagination.js';
 import { getUserOrThrow } from '../services/user.js';
-import { buildUrl } from '../utils/url.js';
 import { requestAndFilterCollection } from '../utils/request-and-filter-collection.js';
 
 export const transactionSchema = z.object({

--- a/packages/proxy/src/routes/transactions-bff.ts
+++ b/packages/proxy/src/routes/transactions-bff.ts
@@ -1,8 +1,45 @@
 import type { FastifyApp } from '../app.js';
-import { buildUrl } from '../utils/url.js';
 import { pipeGetRequest } from '../services/block-explorer.js';
 import { z } from 'zod';
-import { hexSchema } from '../utils/schemas.js';
+import {
+  addressSchema,
+  enumeratedSchema,
+  hexSchema,
+} from '../utils/schemas.js';
+import { wrapIntoPaginationInfo } from '../utils/pagination.js';
+
+export const transactionSchema = z.object({
+  hash: hexSchema,
+  to: addressSchema,
+  from: addressSchema,
+  transactionIndex: z.number(),
+  data: hexSchema,
+  value: z.string(),
+  fee: hexSchema,
+  nonce: z.number(),
+  gasPrice: z.string(),
+  gasLimit: z.string(),
+  gasPerPubdata: z.string(),
+  maxFeePerGas: z.string(),
+  maxPriorityFeePerGas: z.string(),
+  blockNumber: z.number(),
+  blockHash: hexSchema,
+  receivedAt: z.string(),
+  commitTxHash: z.nullable(hexSchema),
+  proveTxHash: z.nullable(hexSchema),
+  executeTxHash: z.nullable(hexSchema),
+  isL1Originated: z.boolean(),
+  l1BatchNumber: z.number(),
+  isL1BatchSealed: z.boolean(),
+  type: z.number(),
+  status: z.string(),
+  error: z.nullable(z.string()),
+  revertReason: z.nullable(z.string()),
+});
+
+const paginatedTransactionsSchema = enumeratedSchema(transactionSchema);
+
+export type Transaction = z.infer<typeof transactionSchema>;
 
 const transactionIndexSchema = {
   schema: {
@@ -41,9 +78,18 @@ const transactionTransfersSchema = {
 const transactionLogsSchema = transactionTransfersSchema;
 
 export function transationsRoutes(app: FastifyApp) {
-  app.get('/', transactionIndexSchema, async (req, reply) => {
-    const targetUrl = `${app.conf.proxyTarget}${req.url}`;
-    return pipeGetRequest(targetUrl, reply);
+  app.get('/', transactionIndexSchema, async (req, _reply) => {
+    const user = req.user;
+    const data = await fetch(`${app.conf.proxyTarget}${req.url}`)
+      .then((res) => res.json())
+      .then((json) => paginatedTransactionsSchema.parse(json));
+
+    const items = data.items.filter((tx) => tx.from === user || tx.to === user);
+    return wrapIntoPaginationInfo(
+      items,
+      `/transactions`,
+      req.query.limit || 10,
+    );
   });
 
   app.get('/:transactionHash', transactionDetailsSchema, async (req, reply) => {

--- a/packages/proxy/src/utils/pagination.ts
+++ b/packages/proxy/src/utils/pagination.ts
@@ -1,0 +1,24 @@
+import { Paginated } from '../routes/address.js';
+
+export function wrapIntoPaginationInfo<T>(
+  collection: T[],
+  linksBaseUri: string,
+  limit: number,
+): Paginated<T> {
+  return {
+    items: collection,
+    meta: {
+      totalItems: collection.length,
+      itemCount: collection.length,
+      itemsPerPage: limit,
+      totalPages: collection.length === 0 ? 0 : 1,
+      currentPage: 1,
+    },
+    links: {
+      first: `${linksBaseUri}?limit=${limit}`,
+      previous: '',
+      next: '',
+      last: `${linksBaseUri}?page=1&limit=${limit}`,
+    },
+  };
+}

--- a/packages/proxy/src/utils/pagination.ts
+++ b/packages/proxy/src/utils/pagination.ts
@@ -1,4 +1,19 @@
-import { Paginated } from '../routes/address.js';
+export type Paginated<T> = {
+  items: T[];
+  meta: {
+    totalItems: number;
+    itemCount: number;
+    itemsPerPage: number;
+    totalPages: number;
+    currentPage: number;
+  };
+  links: {
+    first: string;
+    previous: string;
+    next: string;
+    last: string;
+  };
+};
 
 export function wrapIntoPaginationInfo<T>(
   collection: T[],

--- a/packages/proxy/src/utils/request-and-filter-collection.ts
+++ b/packages/proxy/src/utils/request-and-filter-collection.ts
@@ -1,0 +1,21 @@
+import { buildUrl } from './url.js';
+import { enumeratedSchema } from './schemas.js';
+import { wrapIntoPaginationInfo } from './pagination.js';
+import { z, ZodTypeAny } from 'zod';
+
+export async function requestAndFilterCollection<Parser extends ZodTypeAny>(
+  baseUrl: string,
+  query: Record<string, number | string>,
+  schema: Parser,
+  filter: (elem: z.infer<Parser>) => boolean,
+  limit = 10,
+) {
+  const finalSchema = enumeratedSchema(schema);
+  const res = await fetch(buildUrl(baseUrl, query))
+    .then((res) => res.json())
+    .then((json) => finalSchema.parse(json));
+
+  const filtered = res.items.filter(filter);
+
+  return wrapIntoPaginationInfo(filtered, baseUrl, limit);
+}

--- a/packages/proxy/src/utils/schemas.ts
+++ b/packages/proxy/src/utils/schemas.ts
@@ -51,3 +51,15 @@ export const transferSchema = z.object({
 });
 
 export const enumeratedTransferSchema = enumeratedSchema(transferSchema);
+
+export const logsSchema = z.object({
+  address: addressSchema,
+  blockNumber: z.number(),
+  logIndex: z.number(),
+  data: hexSchema,
+  timestamp: z.string(),
+  topics: z.array(hexSchema),
+  transactionHash: hexSchema,
+  transactionIndex: z.number(),
+});
+export const enumeratedLogSchema = enumeratedSchema(logsSchema);

--- a/packages/proxy/src/utils/schemas.ts
+++ b/packages/proxy/src/utils/schemas.ts
@@ -25,3 +25,29 @@ export function enumeratedSchema<T extends ZodTypeAny>(parser: T) {
     }),
   });
 }
+
+export const tokenSchema = z.object({
+  l2Address: hexSchema,
+  l1Address: hexSchema,
+  symbol: z.string(),
+  name: z.string(),
+  decimals: z.number(),
+  usdPrice: z.number(),
+  liquidity: z.number(),
+  iconURL: z.string(),
+});
+
+export const transferSchema = z.object({
+  from: hexSchema,
+  to: hexSchema,
+  blockNumber: z.number(),
+  transactionHash: hexSchema,
+  amount: z.string(),
+  token: tokenSchema,
+  tokenAddress: hexSchema,
+  type: z.enum(['deposit', 'transfer', 'withdrawal', 'fee', 'mint', 'refund']),
+  timestamp: z.string(),
+  fields: z.any(),
+});
+
+export const enumeratedTransferSchema = enumeratedSchema(transferSchema);

--- a/packages/proxy/src/utils/schemas.ts
+++ b/packages/proxy/src/utils/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z, type ZodTypeAny } from 'zod';
 import type { Address } from 'viem';
 
 export const hexSchema = z.string().regex(/^0x[0-9a-fA-F]*$/);
@@ -6,3 +6,22 @@ export type Hex = z.infer<typeof hexSchema>;
 export const addressSchema = hexSchema
   .length(42)
   .transform((a) => a as Address);
+
+export function enumeratedSchema<T extends ZodTypeAny>(parser: T) {
+  return z.object({
+    items: z.array(parser),
+    meta: z.object({
+      totalItems: z.number(),
+      itemCount: z.number(),
+      itemsPerPage: z.number(),
+      totalPages: z.number(),
+      currentPage: z.number(),
+    }),
+    links: z.object({
+      first: z.string(),
+      previous: z.string(),
+      next: z.string(),
+      last: z.string(),
+    }),
+  });
+}

--- a/packages/proxy/src/utils/schemas.ts
+++ b/packages/proxy/src/utils/schemas.ts
@@ -50,8 +50,6 @@ export const transferSchema = z.object({
   fields: z.any(),
 });
 
-export const enumeratedTransferSchema = enumeratedSchema(transferSchema);
-
 export const logsSchema = z.object({
   address: addressSchema,
   blockNumber: z.number(),
@@ -62,4 +60,3 @@ export const logsSchema = z.object({
   transactionHash: hexSchema,
   transactionIndex: z.number(),
 });
-export const enumeratedLogSchema = enumeratedSchema(logsSchema);

--- a/packages/proxy/test/address-bff.spec.ts
+++ b/packages/proxy/test/address-bff.spec.ts
@@ -66,7 +66,7 @@ describe('/address', () => {
     const contractAddress = '0xe846c6fcf817734ca4527b28ccb4aea2b6663c79';
 
     it('it returns logs indexed to current user address', async () => {
-      backgroundApp?.addAddressLog(contractAddress, [address], '0x01');
+      backgroundApp?.addLog(contractAddress, [address], '0x01');
 
       const app = testInstance();
       const session = await TestSession.loggedIn(app, privateKey);
@@ -77,7 +77,7 @@ describe('/address', () => {
     });
 
     it('it returns skips logs not indexed to the user', async () => {
-      backgroundApp?.addAddressLog(contractAddress, [contractAddress], '0x01');
+      backgroundApp?.addLog(contractAddress, [contractAddress], '0x01');
 
       const app = testInstance();
       const session = await TestSession.loggedIn(app, privateKey);
@@ -94,7 +94,7 @@ describe('/address', () => {
     });
 
     it('accepts logs indexed in other than the first position to the current user', async () => {
-      backgroundApp?.addAddressLog(contractAddress, ['0x01', address], '0x01');
+      backgroundApp?.addLog(contractAddress, ['0x01', address], '0x01');
 
       const app = testInstance();
       const session = await TestSession.loggedIn(app, privateKey);
@@ -104,11 +104,11 @@ describe('/address', () => {
     });
 
     it('it adjusts sizes to only the logs returned and preserves order', async () => {
-      backgroundApp?.addAddressLog(contractAddress, ['0x01', address], '0x01');
-      backgroundApp?.addAddressLog(contractAddress, [address], '0x02');
-      backgroundApp?.addAddressLog(contractAddress, [contractAddress], '0x03');
-      backgroundApp?.addAddressLog(contractAddress, [contractAddress], '0x04');
-      backgroundApp?.addAddressLog(
+      backgroundApp?.addLog(contractAddress, ['0x01', address], '0x01');
+      backgroundApp?.addLog(contractAddress, [address], '0x02');
+      backgroundApp?.addLog(contractAddress, [contractAddress], '0x03');
+      backgroundApp?.addLog(contractAddress, [contractAddress], '0x04');
+      backgroundApp?.addLog(
         contractAddress,
         ['0x01', '0x02', '0x03', address],
         '0x05',

--- a/packages/proxy/test/address-bff.spec.ts
+++ b/packages/proxy/test/address-bff.spec.ts
@@ -50,8 +50,14 @@ describe('/address', () => {
     it('when user logged in bypass request to main api twice', async () => {
       const app = testInstance();
       const session = await TestSession.loggedIn(app, privateKey);
-      const res = await session.getJson(`/address/${address}`, testResponseSchema);
-      const res2 = await session.getJson(`/address/${address}`, testResponseSchema);
+      const res = await session.getJson(
+        `/address/${address}`,
+        testResponseSchema,
+      );
+      const res2 = await session.getJson(
+        `/address/${address}`,
+        testResponseSchema,
+      );
       expect(res).toEqual(res2);
     });
   });

--- a/packages/proxy/test/batch-bff.spec.ts
+++ b/packages/proxy/test/batch-bff.spec.ts
@@ -19,7 +19,9 @@ describe('/blocks', () => {
 
   const secret = Buffer.alloc(32).fill(0).toString('hex');
   const testSession = () => {
-    const app = buildApp(secret, 'development', backgroundApp.url(), false);
+    const app = buildApp(secret, 'development', backgroundApp.url(), false, [
+      '*',
+    ]);
     return new TestSession(app);
   };
 

--- a/packages/proxy/test/blocks-bff.spec.ts
+++ b/packages/proxy/test/blocks-bff.spec.ts
@@ -20,7 +20,9 @@ describe('/blocks', () => {
   const secret = Buffer.alloc(32).fill(0).toString('hex');
 
   const testSession = () => {
-    const app = buildApp(secret, 'development', backgroundApp.url(), false);
+    const app = buildApp(secret, 'development', backgroundApp.url(), false, [
+      '*',
+    ]);
     return new TestSession(app);
   };
 

--- a/packages/proxy/test/transactions-bff.spec.ts
+++ b/packages/proxy/test/transactions-bff.spec.ts
@@ -153,11 +153,34 @@ describe('/transactions', () => {
         '/transactions/0x0001/transfers',
         z.any(),
       );
-      console.log(body);
+
       expect(status).toEqual(200);
       expect(body.items).toHaveLength(2);
       expect(body.items.map((i: any) => i.amount)).toEqual(
         expect.arrayContaining(['1', '2']),
+      );
+    });
+  });
+
+  describe('GET /transactions/:hash/logs', () => {
+    it('only returns transfers made from or to the user', async () => {
+      backgroundApp.addLog(anotherAddress, [address], '0x01');
+      backgroundApp.addLog(anotherAddress, [someOtherAddress], '0x02');
+      backgroundApp.addLog(address, [someOtherAddress, anotherAddress], '0x03');
+      backgroundApp.addLog(anotherAddress, [someOtherAddress, address], '0x04');
+
+      const app = testInstance();
+      const session = await TestSession.loggedIn(app, privateKey);
+
+      const { status, body } = await session.getJson(
+        '/transactions/0x0001/logs',
+        z.any(),
+      );
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(3);
+      expect(body.items.map((i: any) => i.data)).toEqual(
+        expect.arrayContaining(['0x01', '0x03', '0x04']),
       );
     });
   });

--- a/packages/proxy/test/transactions-bff.spec.ts
+++ b/packages/proxy/test/transactions-bff.spec.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.js';
+import { privateKeyToAccount } from 'viem/accounts';
+import { TestProxy } from './util/test-proxy-target.js';
+import { TestSession } from './util/test-session.js';
+import { z } from 'zod';
+import { bytesToHex, zeroAddress } from 'viem';
+
+describe('/transactions', () => {
+  const backgroundApp = new TestProxy();
+  beforeAll(async () => {
+    await backgroundApp.start();
+  });
+
+  afterAll(async () => {
+    await backgroundApp.stop();
+  });
+
+  beforeEach(() => {
+    backgroundApp.reset();
+  });
+
+  const secret = Buffer.alloc(32).fill(0).toString('hex');
+  const privateKey =
+    '0x4f31daab592fe9e35cd47c5fb2db635a25956a9b2023fb6d450e9919f433a262';
+  const account = privateKeyToAccount(privateKey);
+  const address = account.address;
+  const testInstance = () =>
+    buildApp(secret, 'development', 'http://localhost:9191', false, []);
+
+  describe('GET /transactions', () => {
+    it('when user is logged in returns transactions where user is source', async () => {
+      backgroundApp.addTransaction(address, zeroAddress, '0x01');
+      backgroundApp.addTransaction(address, zeroAddress, '0x02');
+
+      const app = testInstance();
+      const session = await TestSession.loggedIn(app, privateKey);
+
+      const { status, body } = await session.getJson('/transactions', z.any());
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(2);
+      expect(body.items.map((i: any) => i.hash)).toEqual(
+        expect.arrayContaining(['0x01', '0x02']),
+      );
+    });
+
+    it('filters out transactions where user is not source or address', async () => {
+      const anotherAddress = bytesToHex(Buffer.alloc(20).fill(1));
+      const someOtherAddress = bytesToHex(Buffer.alloc(20).fill(2));
+      backgroundApp.addTransaction(anotherAddress, someOtherAddress, '0x01');
+      backgroundApp.addTransaction(someOtherAddress, anotherAddress, '0x02');
+
+      const app = testInstance();
+      const session = await TestSession.loggedIn(app, privateKey);
+
+      const { status, body } = await session.getJson('/transactions', z.any());
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(0);
+    });
+
+    it('when user is logged in returns transactions where user is target', async () => {
+      backgroundApp.addTransaction(zeroAddress, address, '0x01');
+      backgroundApp.addTransaction(zeroAddress, address, '0x02');
+
+      const app = testInstance();
+      const session = await TestSession.loggedIn(app, privateKey);
+
+      const { status, body } = await session.getJson('/transactions', z.any());
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(2);
+      expect(body.items.map((i: any) => i.hash)).toEqual(
+        expect.arrayContaining(['0x01', '0x02']),
+      );
+    });
+
+    it('when user is logged in filters only right transactions', async () => {
+      const anotherAddress = bytesToHex(Buffer.alloc(20).fill(1));
+      const someOtherAddress = bytesToHex(Buffer.alloc(20).fill(2));
+      backgroundApp.addTransaction(anotherAddress, someOtherAddress, '0x01');
+      backgroundApp.addTransaction(anotherAddress, address, '0x02');
+      backgroundApp.addTransaction(someOtherAddress, anotherAddress, '0x03');
+      backgroundApp.addTransaction(address, someOtherAddress, '0x04');
+
+      const app = testInstance();
+      const session = await TestSession.loggedIn(app, privateKey);
+
+      const { status, body } = await session.getJson('/transactions', z.any());
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(2);
+      expect(body.items.map((i: any) => i.hash)).toEqual(
+        expect.arrayContaining(['0x02', '0x04']),
+      );
+    });
+
+    it('when no user logged in returns empty array', async () => {
+      backgroundApp.addTransaction(zeroAddress, address, '0x01');
+
+      const app = testInstance();
+      const session = new TestSession(app);
+
+      const { status, body } = await session.getJson('/transactions', z.any());
+
+      expect(status).toEqual(200);
+      expect(body.items).toHaveLength(0);
+    });
+  });
+});

--- a/packages/proxy/test/util/test-proxy-target.ts
+++ b/packages/proxy/test/util/test-proxy-target.ts
@@ -60,14 +60,14 @@ type Wrapped<T> = {
 export class TestProxy {
   private port: number;
   private app: FastifyApp;
-  private addressLogs: Log[];
+  private logs: Log[];
   private transfers: Transfer[];
   private transactions: Transaction[];
 
   constructor(port = 9191) {
     this.port = port;
     this.app = fastify().withTypeProvider<ZodTypeProvider>();
-    this.addressLogs = [];
+    this.logs = [];
     this.transfers = [];
     this.transactions = [];
   }
@@ -76,8 +76,8 @@ export class TestProxy {
     return `http://localhost:${this.port}`;
   }
 
-  addAddressLog(srcAddr: Address, topics: Hex[], data: Hex) {
-    this.addressLogs.push({
+  addLog(srcAddr: Address, topics: Hex[], data: Hex) {
+    this.logs.push({
       address: srcAddr,
       blockNumber: 100,
       logIndex: 1,
@@ -85,7 +85,7 @@ export class TestProxy {
       timestamp: new Date().toISOString(),
       topics: topics,
       transactionHash: bytesToHex(randomBytes(32)),
-      transactionIndex: this.addressLogs.length,
+      transactionIndex: this.logs.length,
     });
   }
 
@@ -114,7 +114,7 @@ export class TestProxy {
   }
 
   reset() {
-    this.addressLogs = [];
+    this.logs = [];
     this.transfers = [];
     this.transactions = [];
   }
@@ -123,9 +123,9 @@ export class TestProxy {
     return {
       items: collection,
       meta: {
-        totalItems: this.addressLogs.length,
-        itemCount: this.addressLogs.length,
-        itemsPerPage: this.addressLogs.length,
+        totalItems: this.logs.length,
+        itemCount: this.logs.length,
+        itemsPerPage: this.logs.length,
         totalPages: 1,
         currentPage: 1,
       },
@@ -145,7 +145,7 @@ export class TestProxy {
           address: hexSchema,
         })
         .parse(request.params);
-      return this.wrapResponse(this.addressLogs, `/address/${address}/logs`);
+      return this.wrapResponse(this.logs, `/address/${address}/logs`);
     });
 
     this.app.get('/address/:address/transfers', async (request, _reply) => {
@@ -167,6 +167,15 @@ export class TestProxy {
         this.transfers,
         `/transactions/${hash}/transfers`,
       );
+    });
+
+    this.app.get('/transactions/:hash/logs', async (request, _reply) => {
+      const { hash } = z
+        .object({
+          hash: hexSchema,
+        })
+        .parse(request.params);
+      return this.wrapResponse(this.logs, `/transactions/${hash}/logs`);
     });
 
     this.app.get('/transactions', async (_req, _reply) => {

--- a/packages/proxy/test/util/test-proxy-target.ts
+++ b/packages/proxy/test/util/test-proxy-target.ts
@@ -157,6 +157,18 @@ export class TestProxy {
       return this.wrapResponse(this.transfers, `/address/${address}/transfers`);
     });
 
+    this.app.get('/transactions/:hash/transfers', async (request, _reply) => {
+      const { hash } = z
+        .object({
+          hash: hexSchema,
+        })
+        .parse(request.params);
+      return this.wrapResponse(
+        this.transfers,
+        `/transactions/${hash}/transfers`,
+      );
+    });
+
     this.app.get('/transactions', async (_req, _reply) => {
       return this.wrapResponse(this.transactions, `/transactions`);
     });


### PR DESCRIPTION
# What ❔

Logic to filter `/transactions` endpoints.

## Why ❔

Transaction discovery is not open in the context of double zero. Users can only discover transactions sent or received by them. If someone already has a tx id that transaction can always be reached.

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
