### PR TITLE
feat(proxy): consider contracts in /address

### DIFF
--- a/packages/proxy/src/routes/address.ts
+++ b/packages/proxy/src/routes/address.ts
@@ -1,10 +1,16 @@
 import type { FastifyApp } from '../app.js';
 import { z } from 'zod';
-import { isAddressEqual } from 'viem';
+import { type Address, type Hex, isAddressEqual } from 'viem';
 import { pipeGetRequest } from '../services/block-explorer.js';
 import { getUserOrThrow } from '../services/user.js';
-import { ForbiddenError } from '../utils/http-error.js';
-import { addressSchema, logsSchema, transferSchema } from '../utils/schemas.js';
+import { ForbiddenError, HttpError } from '../utils/http-error.js';
+import {
+  addressSchema,
+  hexSchema,
+  logsSchema,
+  tokenSchema,
+  transferSchema,
+} from '../utils/schemas.js';
 import { requestAndFilterCollection } from '../utils/request-and-filter-collection.js';
 
 export const addressParamsSchema = {
@@ -32,14 +38,55 @@ const transfersSchema = {
   }),
 };
 
+const accountBalanceSchema = z.object({
+  balance: z.string(),
+  token: z.nullable(tokenSchema),
+});
+
+const addressResponseSchema = z.union([
+  z.object({
+    type: z.literal('account'),
+    address: addressSchema,
+    blockNumber: z.number(),
+    balances: z.record(hexSchema, accountBalanceSchema),
+    sealedNonce: z.number(),
+    verifiedNonce: z.number(),
+  }),
+  z.object({
+    type: z.literal('contract'),
+    address: addressSchema,
+    bytecode: hexSchema,
+    createdInBlockNumber: z.number(),
+    creatorTxHash: hexSchema,
+    creatorAddress: addressSchema,
+    blockNumber: z.number(),
+    balances: z.record(hexSchema, accountBalanceSchema),
+    totalTransactions: z.number(),
+  }),
+]);
+
 export const addressRoutes = (app: FastifyApp) => {
   const proxyTarget = app.conf.proxyTarget;
-  app.get('/:address', { schema: addressParamsSchema }, async (req, reply) => {
-    const user = getUserOrThrow(req);
-    if (!isAddressEqual(req.params.address, user)) {
-      throw new ForbiddenError('Forbidden');
+  app.get('/:address', { schema: addressParamsSchema }, async (req, _reply) => {
+    const data = await fetch(`${proxyTarget}/address/${req.params.address}`)
+      .then((res) => res.json())
+      .then((json) => addressResponseSchema.parse(json));
+
+    if (data.type === 'contract') {
+      return {
+        ...data,
+        balances: {},
+      };
+    } else if (data.type === 'account') {
+      const user = getUserOrThrow(req);
+      if (isAddressEqual(data.address, user)) {
+        return data;
+      } else {
+        throw new ForbiddenError('Forbidden');
+      }
+    } else {
+      throw new HttpError(`Unknown account type: ${data}`, 424);
     }
-    return pipeGetRequest(`${proxyTarget}/address/${user}`, reply);
   });
 
   app.get(

--- a/packages/proxy/src/routes/address.ts
+++ b/packages/proxy/src/routes/address.ts
@@ -84,8 +84,6 @@ export const addressRoutes = (app: FastifyApp) => {
       } else {
         throw new ForbiddenError('Forbidden');
       }
-    } else {
-      throw new HttpError(`Unknown account type: ${data}`, 424);
     }
   });
 

--- a/packages/proxy/src/utils/schemas.ts
+++ b/packages/proxy/src/utils/schemas.ts
@@ -28,14 +28,15 @@ export function enumeratedSchema<T extends ZodTypeAny>(parser: T) {
 
 export const tokenSchema = z.object({
   l2Address: hexSchema,
-  l1Address: hexSchema,
+  l1Address: z.nullable(hexSchema),
   symbol: z.string(),
   name: z.string(),
   decimals: z.number(),
-  usdPrice: z.number(),
-  liquidity: z.number(),
-  iconURL: z.string(),
+  usdPrice: z.nullable(z.number()),
+  liquidity: z.nullable(z.number()),
+  iconURL: z.nullable(z.string()),
 });
+export type TokenData = z.infer<typeof tokenSchema>;
 
 export const transferSchema = z.object({
   from: hexSchema,


### PR DESCRIPTION
# What ❔

Consider contracts in `/address/:address`

## Why ❔

Old logic was assuming that the response was always for an account. But that endpoint can also return data about a contract. We need to consider both cases with different criteria.


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
